### PR TITLE
fix: added some necessary permissions to clusterrole

### DIFF
--- a/chart/templates/clusterrole.yaml
+++ b/chart/templates/clusterrole.yaml
@@ -21,8 +21,12 @@ rules:
   
   - apiGroups: [""]
     resources: ["secrets", "configmaps"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update", "create"]
   
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch", "update"]
+
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "get", "update"]


### PR DESCRIPTION
I open this PR because while testing this provider, I've noticed the following:
- controller tries to create a leases resources but no permissions exist
- controller tries to update and get leases resources for managing tfstate lock
- controller tries to create and update a secret where tfstate is store when kubernetes secret is used as backend